### PR TITLE
팀원 요청에 따른 본인 위치 마커 제거본 (주석처리함)

### DIFF
--- a/src/components/UserInterface/ChargingMap/ChargingMap.jsx
+++ b/src/components/UserInterface/ChargingMap/ChargingMap.jsx
@@ -179,11 +179,11 @@ const KakaoMap = () => {
             const userLng = position.coords.longitude;
             const userLatLng = new window.kakao.maps.LatLng(userLat, userLng);
             map.setCenter(userLatLng);
-            new window.kakao.maps.Marker({
-              map: map,
-              position: userLatLng,
-              title: "현재 위치",
-            });
+            // new window.kakao.maps.Marker({
+            //   map: map,
+            //   position: userLatLng,
+            //   title: "현재 위치",
+            // });
 
             const geocoder = new window.kakao.maps.services.Geocoder();
             geocoder.coord2RegionCode(userLng, userLat, (result, status) => {


### PR DESCRIPTION
[충전소 본인위치 마커 제거]

작성자 : 이성준
작성일 : 25-04-17 오전 11:31분

내용 : 
의견을 반영하여 충전소에서 정확하게 본인 위치가 표시 안되는 이슈로 인해 본인 위치 마커 제거 의견이 나왔고
그로 인해 본인 위치를 마커로 표시 해주는걸 제거 하였습니다.(주석 처리됨)