### PR TITLE
Feature/news list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import "react-toastify/dist/ReactToastify.css";
 
 /* 드라이빙 루뜨 관련 */
 import DRBoard from "./components/UserInterface/Board/DriverRoute/DriveRouteBoard/DRBoard";
-/* 누스 관련 */
+/* 뉴스 관련 */
 import NewsMain from "./components/UserInterface/News/NewsMain/NewsMain";
 import NewsDetail from "./components/UserInterface/News/NewsDetail/NewsDetail";
 import NewsList from "./components/UserInterface/News/NewsList/NewsList";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import NewsMain from "./components/UserInterface/News/NewsMain/NewsMain";
 import NewsDetail from "./components/UserInterface/News/NewsDetail/NewsDetail";
 import NewsList from "./components/UserInterface/News/NewsList/NewsList";
 import MyNews from "./components/UserInterface/News/MyNews/MyNews";
+import AdminNews from "./components/AdminInterface/News/NewsAdminPage";
 
 /* 충전소 위치 관련 */
 import ChargingMap from "./components/UserInterface/ChargingMap/ChargingMap";
@@ -114,7 +115,6 @@ function App() {
 
             <Route path="/updatePwPage" element={<UpdatePwPage />} />
 
-
             {/* 신고 관련 */}
             <Route path="/report/*" element={<Report useDummyData={true} />} />
             <Route
@@ -209,6 +209,9 @@ function App() {
                 path="/admin/reports/:boardNo"
                 element={<ReportDetail useDummyData={true} />}
               />
+
+              {/* 뉴스 관련 */}
+              <Route path="/admin/adminNews" element={<AdminNews />} />
             </Route>
           </Route>
         </Routes>

--- a/src/components/AdminInterface/AdminCommon/AdminHeader/AdminHeader.jsx
+++ b/src/components/AdminInterface/AdminCommon/AdminHeader/AdminHeader.jsx
@@ -24,7 +24,9 @@ const Header = () => {
           <StyledHeaderBtn onClick={() => navi("/admin/carManagement")}>
             렌트카
           </StyledHeaderBtn>
-          <StyledHeaderBtn>커뮤니티</StyledHeaderBtn>
+          <StyledHeaderBtn onClick={() => navi("/admin/adminNews/")}>
+            커뮤니티
+          </StyledHeaderBtn>
           <StyledHeaderBtn onClick={() => navi("/admin/notice/")}>
             공지사항
           </StyledHeaderBtn>

--- a/src/components/AdminInterface/AdminCommon/AdminNav/AdminComunityNav.jsx
+++ b/src/components/AdminInterface/AdminCommon/AdminNav/AdminComunityNav.jsx
@@ -1,0 +1,25 @@
+import { NavDiv, StyledHeaderBtn, NavBoardContentDiv } from "./Nav.styles";
+import { useNavigate } from "react-router-dom";
+
+const CommunityNav = () => {
+  const navi = useNavigate();
+  return (
+    <>
+      <NavDiv>
+        <NavBoardContentDiv>
+          <StyledHeaderBtn onClick={() => navi("/admin/")}>
+            커뮤니티 관련?
+          </StyledHeaderBtn>
+          <StyledHeaderBtn onClick={() => navi("/admin/")}>
+            커뮤니티 관련?
+          </StyledHeaderBtn>
+          <StyledHeaderBtn onClick={() => navi("/admin/adminNews")}>
+            뉴스 관리자
+          </StyledHeaderBtn>
+        </NavBoardContentDiv>
+      </NavDiv>
+    </>
+  );
+};
+
+export default CommunityNav;

--- a/src/components/AdminInterface/News/NewsAdminPage.jsx
+++ b/src/components/AdminInterface/News/NewsAdminPage.jsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import axios from "axios";
+import {
+  removeHtmlTags,
+  formatDate,
+} from "../../UserInterface/News/NewsMain/NewsItemComponents";
+import { Report2, Report3 } from "../Report/AdminReport/AdminReport.styled";
+import CommunityNav from "../AdminCommon/AdminNav/AdminComunityNav";
+
+const backendUrl = "http://localhost:80";
+
+const NewsAdminPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [categories, setCategories] = useState([]);
+  const [newsList, setNewsList] = useState([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortOption, setSortOption] = useState("latest");
+  const [selectedCategory, setSelectedCategory] = useState("");
+
+  const [newCategory, setNewCategory] = useState("");
+  const [editingCategoryNo, setEditingCategoryNo] = useState(null);
+  const [editingCategoryName, setEditingCategoryName] = useState("");
+
+  const [searchClicked, setSearchClicked] = useState(false);
+
+  const navigate = useNavigate();
+  const page = parseInt(searchParams.get("page") || "1");
+  const size = 5;
+
+  useEffect(() => {
+    fetchCategories();
+    fetchNews();
+    setSearchParams({ page: 1 });
+  }, []);
+
+  const fetchCategories = async () => {
+    try {
+      const res = await axios.get(`${backendUrl}/api/admin/news/category/all`);
+      setCategories(res.data);
+    } catch (err) {
+      console.error("카테고리 목록 불러오기 실패", err);
+    }
+  };
+
+  const fetchNews = async () => {
+    try {
+      const res = await axios.get(`${backendUrl}/api/admin/news/list`);
+      setNewsList(res.data || []);
+    } catch (err) {
+      console.error("뉴스 목록 불러오기 실패", err);
+    }
+  };
+
+  const handlePageChange = (newPage) => {
+    setSearchParams({ page: newPage });
+  };
+
+  const handleChatClick = async (item) => {
+    navigate("/newsDetail", {
+      state: {
+        title: removeHtmlTags(item.title),
+        description: removeHtmlTags(item.description),
+        pubDate: formatDate(item.pubDate),
+        imageUrl: item.imageUrl,
+        originallink: item.originUrl,
+        query: item.query,
+      },
+    });
+  };
+
+  const handleAddCategory = async () => {
+    if (!newCategory.trim()) return;
+    try {
+      await axios.post(`${backendUrl}/api/admin/news/category`, {
+        newsCategory: newCategory,
+      });
+      setNewCategory("");
+      fetchCategories();
+    } catch (err) {
+      console.error("카테고리 추가 실패", err);
+    }
+  };
+
+  const handleDeleteCategory = async (newsCategoryNo) => {
+    try {
+      await axios.delete(
+        `${backendUrl}/api/admin/news/category/${newsCategoryNo}`
+      );
+      fetchCategories();
+    } catch (err) {
+      console.error("카테고리 삭제 실패", err);
+    }
+  };
+
+  const handleEditCategory = async (newsCategoryNo) => {
+    try {
+      await axios.put(
+        `${backendUrl}/api/admin/news/category/${newsCategoryNo}`,
+        {
+          newsCategory: editingCategoryName,
+        }
+      );
+      setEditingCategoryNo(null);
+      setEditingCategoryName("");
+      fetchCategories();
+    } catch (err) {
+      console.error("카테고리 수정 실패", err);
+    }
+  };
+
+  const handleSearchClick = () => {
+    setSearchClicked(!searchClicked); // 강제 렌더링 트리거
+  };
+
+  const filteredNews = newsList
+    .filter(
+      (n) =>
+        (!searchTerm ||
+          removeHtmlTags(n.title || "").includes(searchTerm) ||
+          (n.query && n.query.includes(searchTerm))) &&
+        (!selectedCategory || n.query === selectedCategory)
+    )
+    .sort((a, b) => {
+      if (sortOption === "latest")
+        return new Date(b.pubDate) - new Date(a.pubDate);
+      if (sortOption === "views") return b.count - a.count;
+      return 0;
+    });
+
+  const pagedList = filteredNews.slice((page - 1) * size, page * size);
+  const totalPages = Math.ceil(filteredNews.length / size);
+
+  return (
+    <Report2>
+      <CommunityNav />
+      <Report3>
+        <h1 className="text-2xl font-bold mb-4">뉴스 관리</h1>
+
+        <div className="flex gap-8">
+          {/* 좌측: 카테고리 관리 */}
+          <div className="w-1/3">
+            <h2 className="text-xl font-semibold mb-2">카테고리 관리</h2>
+            <div className="flex gap-2 mb-2">
+              <input
+                type="text"
+                value={newCategory}
+                onChange={(e) => setNewCategory(e.target.value)}
+                placeholder="새 카테고리 입력"
+              />
+              <button onClick={handleAddCategory}>추가</button>
+            </div>
+            <ul className="flex flex-wrap gap-2">
+              {categories.map((cat) => (
+                <li
+                  key={cat.newsCategoryNo}
+                  className="px-3 py-1 bg-gray-200 rounded-full flex items-center gap-2"
+                >
+                  {editingCategoryNo === cat.newsCategoryNo ? (
+                    <>
+                      <input
+                        value={editingCategoryName}
+                        onChange={(e) => setEditingCategoryName(e.target.value)}
+                      />
+                      <button
+                        onClick={() => handleEditCategory(cat.newsCategoryNo)}
+                      >
+                        확인
+                      </button>
+                      <button onClick={() => setEditingCategoryNo(null)}>
+                        취소
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <span>{cat.newsCategory}</span>
+                      <button
+                        onClick={() => {
+                          setEditingCategoryNo(cat.newsCategoryNo);
+                          setEditingCategoryName(cat.newsCategory);
+                        }}
+                      >
+                        수정
+                      </button>
+                      <button
+                        onClick={() => handleDeleteCategory(cat.newsCategoryNo)}
+                      >
+                        삭제
+                      </button>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* 우측: 뉴스 목록 */}
+          <div className="w-2/3">
+            <h2 className="text-xl font-semibold mb-2">뉴스 게시판 관리</h2>
+            <div className="report-filters mb-4 flex gap-2">
+              <input
+                type="text"
+                placeholder="제목 또는 키워드 검색"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+              <select
+                value={sortOption}
+                onChange={(e) => setSortOption(e.target.value)}
+              >
+                <option value="latest">최신순</option>
+                <option value="views">조회수순</option>
+              </select>
+              <select
+                value={selectedCategory}
+                onChange={(e) => setSelectedCategory(e.target.value)}
+              >
+                <option value="">전체</option>
+                {categories.map((cat) => (
+                  <option key={cat.newsCategoryNo} value={cat.newsCategory}>
+                    {cat.newsCategory}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="report-table-container">
+              <table className="report-table">
+                <thead>
+                  <tr>
+                    <th>제목</th>
+                    <th>카테고리</th>
+                    <th>등록일</th>
+                    <th>조회수</th>
+                    <th>상세</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagedList.map((item) => (
+                    <tr key={item.newsNo} className="hover:bg-gray-50">
+                      <td>{removeHtmlTags(item.title)}</td>
+                      <td>{item.query}</td>
+                      <td>{formatDate(item.pubDate)}</td>
+                      <td>{item.count}</td>
+                      <td>
+                        <button onClick={() => handleChatClick(item)}>
+                          📄
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="pagination mt-4">
+              <button
+                onClick={() => handlePageChange(Math.max(1, page - 1))}
+                disabled={page === 1}
+              >
+                ◀ 이전
+              </button>
+              {Array.from({ length: totalPages }, (_, i) => (
+                <button
+                  key={i}
+                  onClick={() => handlePageChange(i + 1)}
+                  className={page === i + 1 ? "active" : ""}
+                >
+                  {i + 1}
+                </button>
+              ))}
+              <button
+                onClick={() => handlePageChange(Math.min(totalPages, page + 1))}
+                disabled={page === totalPages}
+              >
+                다음 ▶
+              </button>
+            </div>
+          </div>
+        </div>
+      </Report3>
+    </Report2>
+  );
+};
+
+export default NewsAdminPage;

--- a/src/components/UserInterface/News/MyNews/MyNews.jsx
+++ b/src/components/UserInterface/News/MyNews/MyNews.jsx
@@ -11,7 +11,6 @@ const backendUrl = "http://localhost:80";
 const MyNews = () => {
   const { auth } = useAuth();
   const memberNo = auth?.user?.memberNo;
-
   const [searchParams, setSearchParams] = useSearchParams();
   const [fullList, setFullList] = useState([]);
   const [imageResults, setImageResults] = useState({});
@@ -33,12 +32,9 @@ const MyNews = () => {
           }
         );
         setFullList(res.data || []);
-
         const updatedImages = {};
         for (const news of res.data || []) {
-          if (news.imageUrl) {
-            updatedImages[news.title] = news.imageUrl;
-          }
+          if (news.imageUrl) updatedImages[news.title] = news.imageUrl;
         }
         setImageResults(updatedImages);
       } catch (err) {
@@ -50,31 +46,19 @@ const MyNews = () => {
     setSearchParams({ page: 1 });
   }, [activeTab, memberNo]);
 
-  const handleTabClick = (tab) => {
-    setActiveTab(tab);
-  };
-
-  const handlePageChange = (newPage) => {
-    setSearchParams({ page: newPage });
-  };
-
-  const getImageUrl = (item) => {
-    return imageResults[item.title] || "/images/loading.png";
-  };
-
   const handleChatClick = async (item) => {
-    const titleKey = removeHtmlTags(item.title);
-    let imageUrl = getImageUrl(item);
+    const key = removeHtmlTags(item.title);
+    let imageUrl = imageResults[key] || "/images/loading.png";
 
     if (imageUrl === "/images/loading.png") {
       try {
         const res = await axios.get(`${backendUrl}/api/naver-image`, {
-          params: { query: titleKey },
+          params: { query: key },
         });
         const hits = res.data.items || [];
         const fetched =
           hits[0]?.thumbnail || hits[0]?.link || "/images/loading.png";
-        setImageResults((prev) => ({ ...prev, [titleKey]: fetched }));
+        setImageResults((prev) => ({ ...prev, [key]: fetched }));
         imageUrl = fetched;
       } catch (e) {
         console.error("이미지 재조회 실패", e);
@@ -99,22 +83,18 @@ const MyNews = () => {
   return (
     <MyPageDiv>
       <MyPageNav />
-
-      {/* 오른쪽 콘텐츠 */}
       <div style={{ flex: 1, padding: "2rem" }}>
         <h2>내 뉴스</h2>
-
-        {/* 탭 */}
         <div style={{ marginBottom: "1rem" }}>
           <button
-            onClick={() => handleTabClick("likes")}
+            onClick={() => setActiveTab("likes")}
             style={{ fontWeight: activeTab === "likes" ? "bold" : "normal" }}
           >
             좋아요한 뉴스
           </button>
           {" | "}
           <button
-            onClick={() => handleTabClick("bookmarks")}
+            onClick={() => setActiveTab("bookmarks")}
             style={{
               fontWeight: activeTab === "bookmarks" ? "bold" : "normal",
             }}
@@ -122,8 +102,6 @@ const MyNews = () => {
             북마크한 뉴스
           </button>
         </div>
-
-        {/* 뉴스 리스트 */}
         <ul>
           {pagedList.map((item) => (
             <li key={item.newsNo} style={{ marginBottom: "1rem" }}>
@@ -138,14 +116,12 @@ const MyNews = () => {
                 {removeHtmlTags(item.title)}
               </strong>
               <p>{removeHtmlTags(item.description)}</p>
-              {getImageUrl(item) !== "/images/loading.png" && (
-                <img src={getImageUrl(item)} alt="" width={100} />
+              {imageResults[item.title] && (
+                <img src={imageResults[item.title]} alt="" width={100} />
               )}
             </li>
           ))}
         </ul>
-
-        {/* 페이지네이션 */}
         <div
           style={{
             marginTop: "1rem",
@@ -157,7 +133,7 @@ const MyNews = () => {
           {Array.from({ length: totalPages }, (_, i) => (
             <button
               key={i}
-              onClick={() => handlePageChange(i + 1)}
+              onClick={() => setSearchParams({ page: i + 1 })}
               disabled={i + 1 === page}
             >
               {i + 1}

--- a/src/components/UserInterface/News/NewsDetail/CommentSection.jsx
+++ b/src/components/UserInterface/News/NewsDetail/CommentSection.jsx
@@ -19,9 +19,9 @@ const CommentSection = ({ newsNo, backendUrl }) => {
   const fetchComments = async () => {
     try {
       const res = await axios.get(`${backendUrl}/api/news/comment/list`, {
-        params: { newsNo, memberNo }, // memberNo 같이 보내야 hasLiked/hasHated 받을 수 있다
+        params: { newsNo, memberNo },
       });
-      setComments(res.data); // 서버가 likes, dislikes, hasLiked, hasHated 모두 내려준다
+      setComments(res.data);
     } catch (error) {
       console.error("댓글 불러오기 실패", error);
     }
@@ -82,7 +82,7 @@ const CommentSection = ({ newsNo, backendUrl }) => {
           params: { newsCmtId: commentId, memberNo },
         });
       }
-      fetchComments(); // 상태를 다시 불러온다
+      fetchComments();
     } catch (error) {
       console.error("좋아요 토글 실패", error);
     }
@@ -111,7 +111,7 @@ const CommentSection = ({ newsNo, backendUrl }) => {
           params: { newsCmtId: commentId, memberNo },
         });
       }
-      fetchComments(); // 상태를 다시 불러온다
+      fetchComments();
     } catch (error) {
       console.error("싫어요 토글 실패", error);
     }
@@ -143,6 +143,21 @@ const CommentSection = ({ newsNo, backendUrl }) => {
       fetchComments();
     } catch (error) {
       console.error("댓글 삭제 실패", error);
+    }
+  };
+
+  const handleReportComment = async (commentId) => {
+    if (!window.confirm("해당 댓글을 신고하시겠습니까?")) return;
+    try {
+      await axios.post(`${backendUrl}/api/report/comment`, {
+        newsCmtId: commentId,
+        reporter: memberNo,
+        reportReason: "부적절한 내용", // 예시
+      });
+      alert("신고가 접수되었습니다.");
+    } catch (error) {
+      console.error("댓글 신고 실패", error);
+      alert("신고 처리 중 오류 발생");
     }
   };
 
@@ -233,6 +248,13 @@ const CommentSection = ({ newsNo, backendUrl }) => {
                         </Button>
                       </>
                     )}
+                    <Button
+                      size="sm"
+                      variant="outline-warning"
+                      onClick={() => handleReportComment(comment.id)}
+                    >
+                      🚨 신고
+                    </Button>
                   </S.CommentActions>
                   {replyTargetId === comment.id && (
                     <div style={{ marginTop: "10px" }}>

--- a/src/components/UserInterface/News/NewsDetail/NewsDetail.jsx
+++ b/src/components/UserInterface/News/NewsDetail/NewsDetail.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as S from "./NewsDetail.styles";
+import * as S1 from "../NewsMain/NewsMain.styles";
 import { Button } from "react-bootstrap";
 import axios from "axios";
 import { useAuth } from "../../Context/AuthContext/AuthContext";
@@ -191,9 +192,13 @@ const NewsDetail = ({ backendUrl = "http://localhost:80" }) => {
           <S.ArticleCategory>{article.pubDate}</S.ArticleCategory>
           <S.ArticleText>
             <h2>{article.title}</h2>
-            <h5>기사의 요약 내용</h5>
+            <h5>
+              <S1.SectionIcon>|</S1.SectionIcon>기사의 요약 내용
+            </h5>
             <div>{article.description}</div>
-            <div>기사 이미지</div>
+            <div>
+              <S1.SectionIcon>|</S1.SectionIcon>기사 이미지
+            </div>
             <img
               src={article.imageUrl}
               alt="기사 이미지"

--- a/src/components/UserInterface/News/NewsDetail/NewsDetail.jsx
+++ b/src/components/UserInterface/News/NewsDetail/NewsDetail.jsx
@@ -20,7 +20,6 @@ const NewsDetail = ({ backendUrl = "http://localhost:80" }) => {
   const [hasLiked, setHasLiked] = useState(false);
   const [hasHated, setHasHated] = useState(false);
   const memberNo = Number(localStorage.getItem("memberNo"));
-  // const memberNo = 161;
 
   useEffect(() => {
     if (!title || !originallink) return;
@@ -38,7 +37,7 @@ const NewsDetail = ({ backendUrl = "http://localhost:80" }) => {
         },
         {
           params: {
-            memberNo: memberNo, // ← 추가!
+            memberNo: memberNo,
           },
         }
       )
@@ -178,6 +177,30 @@ const NewsDetail = ({ backendUrl = "http://localhost:80" }) => {
     }
   };
 
+  const handleBlock = () => {
+    if (!auth?.user || !article) {
+      alert("로그인이 필요하거나 뉴스 정보가 없습니다.");
+      return;
+    }
+
+    navigate("/reportingPage", {
+      state: {
+        boardInfo: {
+          boardId: article.newsNo,
+          boardTitle: article.title,
+        },
+        reporter: {
+          userId: auth.user.memberNo,
+          userName: auth.user.name,
+        },
+        reported: {
+          userId: article.newsNo,
+          userName: "뉴스 게시판 신고",
+        },
+      },
+    });
+  };
+
   if (!article) return <S.Loading>기사를 불러오는 중입니다...</S.Loading>;
 
   return (
@@ -248,6 +271,14 @@ const NewsDetail = ({ backendUrl = "http://localhost:80" }) => {
                   onClick={handleBookmark}
                 >
                   {bookmarked ? "🔖 북마크됨" : "📌 북마크"}
+                </Button>
+
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={handleBlock}
+                >
+                  ⛔게시판 차단
                 </Button>
               </>
             )}

--- a/src/components/UserInterface/News/NewsMain/NewsMain.jsx
+++ b/src/components/UserInterface/News/NewsMain/NewsMain.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
@@ -24,8 +22,7 @@ const NewsMain = ({ backendUrl = "http://localhost:80" }) => {
   const [topNews, setTopNews] = useState([]);
   const [mainNews, setMainNews] = useState([]);
   const [listNews, setListNews] = useState([]);
-
-  const keywords = ["전기차", "에너지", "태양광", "풍력", "수소"];
+  const [keywords, setKeywords] = useState([]); // ✅ 카테고리 상태 추가
 
   const handleSearch = (searchQuery = query) => {
     if (!searchQuery.trim()) return;
@@ -39,7 +36,7 @@ const NewsMain = ({ backendUrl = "http://localhost:80" }) => {
 
     axios
       .get(`${backendUrl}/api/naver-news`, {
-        params: { query: searchQuery, display: 100, start: 1 },
+        params: { query: searchQuery, display: 20, start: 1 },
       })
       .then((res) => {
         clearTimeout(timeoutId);
@@ -158,6 +155,23 @@ const NewsMain = ({ backendUrl = "http://localhost:80" }) => {
 
   useEffect(() => {
     setLoading(true);
+
+    axios
+      .get(`${backendUrl}/api/news/categories`)
+      .then((res) => {
+        const list = res.data
+          .map((item) => item.newsCategory)
+          .filter((name) => name && name !== "기타");
+
+        console.log("✅ 최종 카테고리 목록:", list);
+        setKeywords(list);
+      })
+
+      .catch((err) => {
+        console.error("❌ 카테고리 로딩 실패", err);
+        setKeywords(["전기차"]); // fallback
+      });
+
     handleSearch();
     window.scrollTo(0, 0);
   }, []);


### PR DESCRIPTION
[뉴스 관리자 기능, 뉴스게시판 댓글 신고,차단 완료 ]
작성자 : 박태현
작성일 : 2025-05-06 오후 21:09

뉴스 관리자 기능페이지를 추가하였습니다. 
커뮤니티 헤더를 통해 들어갈 수 있습니다.

뉴스 카테고리를 추가 수정 삭제 할 수 있음
현재 생성되어있는 게시판들을 기간별로 전체 조회하는 기능을 가지고 있습니다.


댓글 신고는 버튼을 누르고 확인하면 바로 요청처리를 벡앤드로 넘겨서 성공하면 완료됩니다.
뉴스 게시판 차단버튼을 누르면 reportingPage로 값을 넘겨이동합니다.

SearchBar 아래의 카테고리 버튼들이 뉴스 카테고리 DB를 select해서 보도록 수정하였습니다.